### PR TITLE
Fix memory leak in assignment operator

### DIFF
--- a/Vector.cpp
+++ b/Vector.cpp
@@ -22,6 +22,12 @@ Vector<T>& Vector<T>::operator=(const Vector& other) {
     }
 
     size = other.size;
+
+    // deleting initial arr
+    if (arr != nullptr){
+	delete[] arr;
+    }
+
     arr = new T[size];
     for (size_t i = 0; i < size; ++i) {
         arr[i] = other.arr[i];


### PR DESCRIPTION
Fixes issue #1 
Deleting initial **arr** in assignment operator in `Vector.cpp`

```c++
template <typename T>
Vector<T>& Vector<T>::operator=(const Vector& other) {
    if (this == &other) {
        return *this;
    }

    size = other.size;

    // deleting initial arr
    if (arr != nullptr){
        delete[] arr;
    }

    arr = new T[size];
    for (size_t i = 0; i < size; ++i) {
        arr[i] = other.arr[i];
    }

    return *this;
}

```